### PR TITLE
Add simple docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
-#![warn(bad_style, missing_docs,
-        unused, unused_extern_crates, unused_import_braces,
-        unused_qualifications, unused_results)]
+//! Provides utility methods for basic interaction with Twitter API.
+
+#![warn(bad_style)]
+#![warn(missing_docs)]
+#![warn(unused)]
+#![warn(unused_extern_crates)]
+#![warn(unused_import_braces)]
+#![warn(unused_qualifications)]
+#![warn(unused_results)]
 
 extern crate oauth_client as oauth;
 
@@ -15,6 +21,7 @@ mod api {
     pub const STATUSES_UPDATE: &'static str = "https://api.twitter.com/1.1/statuses/update.json";
 }
 
+/// Creates a map from query parameter key value pairs.
 fn split_query<'a>(query: &'a str) -> HashMap<Cow<'a, str>, Cow<'a, str>> {
     let mut param = HashMap::new();
     for q in query.split('&') {
@@ -26,6 +33,7 @@ fn split_query<'a>(query: &'a str) -> HashMap<Cow<'a, str>, Cow<'a, str>> {
     param
 }
 
+/// Fetch token and token secret and construct a new request token from query params
 pub fn get_request_token(consumer: &Token) -> Token<'static> {
     let resp = oauth::get(api::REQUEST_TOKEN, consumer, None, None);
     let param = split_query(&resp);
@@ -33,10 +41,12 @@ pub fn get_request_token(consumer: &Token) -> Token<'static> {
                param.get("oauth_token_secret").unwrap().to_string())
 }
 
+/// Format authorize url, combining auth url and request key
 pub fn get_authorize_url(request: &Token) -> String {
     format!("{}?oauth_token={}", api::AUTHORIZE, request.key)
 }
 
+/// Retrieve access token by use of pin, request token
 pub fn get_access_token(consumer: &Token, request: &Token, pin: &str) -> Token<'static> {
     let mut param = HashMap::new();
     let _ = param.insert("oauth_verifier".into(), pin.into());
@@ -46,6 +56,7 @@ pub fn get_access_token(consumer: &Token, request: &Token, pin: &str) -> Token<'
                param.get("oauth_token_secret").unwrap().to_string())
 }
 
+/// With key, secret, and access token, post status to Twitter
 pub fn tweet(consumer: &Token, access: &Token, status: &str) {
     let mut param = HashMap::new();
     let _ = param.insert("status".into(), status.into());


### PR DESCRIPTION
Adding docs was primarily to satisfy compiler warnings about missing
docs, but also to familiarize myself with the libraries.

Compiler plugins were also reorganized for clarity.
