### PR TITLE
Added create call to Config::write()

### DIFF
--- a/examples/tweet.rs
+++ b/examples/tweet.rs
@@ -47,7 +47,7 @@ impl Config {
     }
 
     pub fn write(&self, path_file: &Path) {
-        let mut file = match OpenOptions::new().write(true).open(path_file) {
+        let mut file = match OpenOptions::new().write(true).create(true).open(path_file) {
             Ok(f) => f,
             Err(e) => panic!("{}", e),
         };


### PR DESCRIPTION
Config::write was failing on first time file creation with

```
thread '<main>' panicked at 'No such file or directory (os error 2)',
 src/main.rs:42
```

Adding create call to match block seems to resolve this issue.

Tested on OSX 10.11.
